### PR TITLE
fix: remove inconsistent comments

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -162,5 +162,3 @@ from .omicsdi import OmicsDI
 
 # import mapping
 from . import apps
-
-# import dev


### PR DESCRIPTION
On line 166, `__init__.py` has comment that indicates more modules are to be imported with code that follows. But, the file ends there. It will decrease the ambiguity if said comment is removed. 
```
-
- # import dev
```
