### PR TITLE
Error if only a single replicate is used

### DIFF
--- a/main/py/rnaseq_preprocess.py
+++ b/main/py/rnaseq_preprocess.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import pandas as pd
+
 from project import configs
 import re
 import os
@@ -10,7 +11,10 @@ from rpy2.robjects.packages import importr, SignatureTranslatedAnonymousPackage
 import glob
 import numpy as np
 
-import .async_bioservices
+import async_bioservices
+from async_bioservices.output_database import OutputDatabase
+
+# import .async_bioservices
 from .async_bioservices.output_database import OutputDatabase
 
 # import R libraries
@@ -428,7 +432,7 @@ def main(argv):
     if "[" in context_names[0] and "]" in context_names[-1]:
         print("DEPRECATED: Please use the new method of providing context names, i.e. --context-names 'context1 context2 context3'.")
         print("This can be done by setting the 'context_names' variable to a simple string separated by lists: context_names='context1 context2 context3'")
-        print("Your current method of passing context names will be removed in the future. Please update your variables above accordingly!")
+        print("Your current method of passing context names will be removed in the future. Please update your variables above accordingly!\n\n")
         temp_context_names: list[str] = []
         for name in context_names:
             temp_name = name.replace("'", "").replace(" ", "")

--- a/main/py/rnaseq_preprocess.py
+++ b/main/py/rnaseq_preprocess.py
@@ -10,7 +10,7 @@ from rpy2.robjects.packages import importr, SignatureTranslatedAnonymousPackage
 import glob
 import numpy as np
 
-from . import async_bioservices
+import .async_bioservices
 from .async_bioservices.output_database import OutputDatabase
 
 # import R libraries
@@ -474,5 +474,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    # print(sys.argv)
     main(sys.argv[1:])

--- a/main/py/rscripts/generate_counts_matrix.R
+++ b/main/py/rscripts/generate_counts_matrix.R
@@ -8,7 +8,6 @@ if (!dir.exists(str_interp("${work_dir}/py/rlogs"))) {
 }
 
 # prevent messy messages from repeatedly writing to juypter
-
 zz <- file(file.path("/home", username, "main", "py", "rlogs", "generate_counts_matrix.Rout"), open="wt")
 sink(zz, type="message")
 
@@ -168,6 +167,7 @@ create_counts_matrix <- function(counts_files, replicate_names, n_replicates, st
     # If the length of n_replicates is 1, then all samples are replicates of the same study
     # Show a warning and exit the script; we cannot have less than 2 replicates
     # Show the replicate name in the warning
+
     if (length(n_replicates) == 1) {
         warning("There is only one replicate for study ", replicate_names[1], ". Please provide at least two replicates.")
         stop()

--- a/main/py/rscripts/generate_counts_matrix.R
+++ b/main/py/rscripts/generate_counts_matrix.R
@@ -165,6 +165,15 @@ prepare_sample_counts <- function(counts_file, counts_files, strand_file) {
 
 
 create_counts_matrix <- function(counts_files, replicate_names, n_replicates, strand_files) {
+    # If the length of n_replicates is 1, then all samples are replicates of the same study
+    # Show a warning and exit the script; we cannot have less than 2 replicates
+    # Show the replicate name in the warning
+    if (length(n_replicates) == 1) {
+        warning("There is only one replicate for study ", replicate_names[1], ". Please provide at least two replicates.")
+        stop()
+    }
+
+
     i_adjust <- 0  # adjusted index, subtracts number of multiruns processed
     counts <- prepare_sample_counts(counts_files[1], counts_files, strand_files[1]) # get first column of counts to add
     


### PR DESCRIPTION
If a single replicate is used as input data, `generate_counts_matrix.R` (used by `rnaseq_preprocess.py`) will show an error and exit

This will resolve #31 